### PR TITLE
Added non-uniform convolution routine

### DIFF
--- a/bbconv.f90
+++ b/bbconv.f90
@@ -131,3 +131,43 @@ subroutine convR(obspec,modspec,R,Fratio_int)
 
 
 end subroutine convR
+
+
+subroutine convNONuniformR(obspec,modspec,R,Fratio_int)
+
+  implicit none
+
+
+  !f2py intent(inout) modspec,obspec, R
+  !f2py intent(out) Fratio_int
+
+  integer, parameter:: maxwave = 40000
+  double precision,intent(inout) :: modspec(:,:),obspec(:,:), R(:)
+  double precision,dimension(maxwave),intent(out) :: Fratio_int
+  double precision,allocatable,dimension(:):: wlobs,gauss,wlmod,Fmod
+  integer :: i, nwmod, nobs,nmod
+  double precision:: sigma
+
+  nobs = size(obspec(1,:))
+  nmod = size(modspec(1,:))
+
+  allocate(wlobs(nobs))
+  allocate(gauss(nmod),wlmod(nmod),Fmod(nmod))
+
+  Fmod = modspec(2,:)
+  wlmod = modspec(1,:)
+  wlobs = obspec(1,:)
+
+  do i = 1, nobs
+     sigma = (wlobs(i) / R(i)) / 2.355
+     gauss = exp(-(wlmod-wlobs(i))**2/(2*sigma**2))
+     gauss = gauss/ sum(gauss)
+     Fratio_int(i)= sum(gauss*Fmod)
+  end do
+
+  deallocate(wlobs)
+  deallocate(gauss,wlmod,Fmod)
+
+
+
+end subroutine convNONuniformR

--- a/bensconv.py
+++ b/bensconv.py
@@ -2,6 +2,7 @@ import numpy as np
 from bbconv import prism
 from bbconv import convfwhm
 from bbconv import convr
+from bbconv import convnonuniformr
 
 #**************************************************************************
 
@@ -26,11 +27,16 @@ def conv_uniform_FWHM(obspec,modspec,fwhm):
     return fluxout
 
 
-        
-
 def conv_uniform_R(obspec,modspec,R):
 
     fluxout = convr(np.asfortranarray(obspec),np.asfortranarray(modspec),R)[0:obspec[0,:].size]
     
+
+    return fluxout
+
+
+def conv_non_uniform_R(obspec, modspec, R):
+
+    fluxout = convnonuniformr(np.asfortranarray(obspec), np.asfortranarray(modspec), np.asfortranarray(R))[0:obspec[0, :].size]
 
     return fluxout

--- a/brewtools.py
+++ b/brewtools.py
@@ -59,6 +59,7 @@ def proc_spec(shiftspec,theta,fwhm,chemeq,gasnum,obspec):
     from bensconv import prism_non_uniform
     from bensconv import conv_uniform_R
     from bensconv import conv_uniform_FWHM
+    from bensconv import conv_non_uniform_R
 
     if chemeq == 0:
         if (gasnum[gasnum.size-1] == 22):
@@ -93,10 +94,23 @@ def proc_spec(shiftspec,theta,fwhm,chemeq,gasnum,obspec):
         
         outspec = conv_uniform_FWHM(obspec,modspec,fwhm)
 
-    elif (fwhm > 10.00):
+    elif (fwhm > 10.00 and fwhm < 900.00):
         # this is a uniform resolving power R.
         Res = fwhm
         outspec = conv_uniform_R(obspec,modspec,Res)
+
+    elif (fwhm == 999):
+        R = obspec[-1, :]
+        mr_NIRSpec = np.where(modspec[0, :] < 5.2)[0]
+        or_NIRSpec = np.where(obspec[0, :] < 5.2)[0]
+
+        mr_MIRI = np.where(np.logical_and(modspec[0, :] > 5.2, modspec[0, :] <= obspec[0,-1]))[0]
+        or_MIRI = np.where(np.logical_and(obspec[0, :] > 5.2, obspec[0, :] <= obspec[0,-1]))[0]
+
+        NIRSpec = conv_non_uniform_R(obspec[:, or_NIRSpec], modspec[:, mr_NIRSpec], R[or_NIRSpec])
+        MIRI = conv_non_uniform_R(obspec[:, or_MIRI], modspec[:, mr_MIRI], R[or_MIRI])
+
+        outspec = np.array(np.concatenate((NIRSpec,MIRI),axis=0))
 
     elif (fwhm == 0.0):
         # Use Mike's convolution for Spex

--- a/nestkit.py
+++ b/nestkit.py
@@ -20,6 +20,7 @@ from astropy.convolution import Gaussian1DKernel
 from bensconv import prism_non_uniform
 from bensconv import conv_uniform_R
 from bensconv import conv_uniform_FWHM
+from bensconv import conv_non_uniform_R
 
 __author__ = "Ben Burningham"
 __copyright__ = "Copyright 2015 - Ben Burningham"
@@ -439,8 +440,9 @@ def lnlike(theta):
         else:
             s2 = obspec[2,:]**2
 
-        lnLik=-0.5*np.sum((((obspec[1,:] - spec[:])**2) / s2) + np.log(2.*np.pi*s2))       
-    elif (fwhm > 10.00):
+        lnLik=-0.5*np.sum((((obspec[1,:] - spec[:])**2) / s2) + np.log(2.*np.pi*s2))      
+
+    elif (fwhm > 10.00 and fwhm < 900.00):
         # this is a uniform resolving power R.
         Res = fwhm
         spec = conv_uniform_R(obspec,modspec,Res)
@@ -450,6 +452,21 @@ def lnlike(theta):
             s2 = obspec[2,:]**2
 
         lnLik=-0.5*np.sum((((obspec[1,:] - spec[:])**2) / s2) + np.log(2.*np.pi*s2))
+
+    elif (fwhm == 999.0):
+        
+        if (do_fudge == 1):
+            R = obspec[-1, :]
+            spec = conv_non_uniform_R(obspec, modspec, R)
+            s2 = obspec[2, :] ** 2 + 10. ** logf
+            lnLik = -0.5 * np.sum((((obspec[1, :] - spec[:]) ** 2) / s2) + np.log(2. * np.pi * s2))
+
+         else:
+            R = obspec[-1, :]
+            spec = conv_non_uniform_R(obspec, modspec, R)
+            s2 = obspec[2, :] ** 2
+            lnLik = -0.5 * np.sum((((obspec[1, :] - spec[:]) ** 2) / s2) + np.log(2. * np.pi * s2))
+        
     elif (fwhm == 0.0):
         # Use convolution for Spex
         spec = prism_non_uniform(obspec,modspec,3.3)

--- a/testkit.py
+++ b/testkit.py
@@ -22,6 +22,7 @@ from rotBroadInt import rot_int_cmj as rotBroad
 from bensconv import prism_non_uniform
 from bensconv import conv_uniform_R
 from bensconv import conv_uniform_FWHM
+from bensconv import conv_non_uniform_R
 
 __author__ = "Ben Burningham"
 __copyright__ = "Copyright 2015 - Ben Burningham"
@@ -791,8 +792,9 @@ def lnlike(theta):
         else:
             s2 = obspec[2,:]**2
 
-        lnLik=-0.5*np.sum((((obspec[1,:] - spec[:])**2) / s2) + np.log(2.*np.pi*s2))       
-    elif (fwhm > 10.00):
+        lnLik=-0.5*np.sum((((obspec[1,:] - spec[:])**2) / s2) + np.log(2.*np.pi*s2))   
+
+    elif (fwhm > 10.00 and fwhm < 900.00):
         # this is a uniform resolving power R.
         Res = fwhm
         spec = conv_uniform_R(obspec,modspec,Res)
@@ -802,6 +804,18 @@ def lnlike(theta):
             s2 = obspec[2,:]**2
 
         lnLik=-0.5*np.sum((((obspec[1,:] - spec[:])**2) / s2) + np.log(2.*np.pi*s2))
+
+    elif (fwhm == 999):
+        # this is a non-uniform resolving power R.
+        R = obspec[-1, :]
+        spec = conv_non_uniform_R(obspec,modspec,R)
+        if (do_fudge == 1):
+            s2=obspec[2,:]**2 + 10.**logf
+        else:
+            s2 = obspec[2,:]**2
+
+        lnLik=-0.5*np.sum((((obspec[1,:] - spec[:])**2) / s2) + np.log(2.*np.pi*s2))
+
     elif (fwhm == 0.0):
         # Use convolution for Spex
         spec = prism_non_uniform(obspec,modspec,3.3)


### PR DESCRIPTION
This pull request adds non-uniform convolution routine in order to handle NIRSpec+MIRI dataset.

**Key changes**

1. Need to have a 4th column in 'obspec' file with resolving power values at each wavelength point but only when using  non-uniform convolution routine.
2. In order to use non-uniform convolution routine set `fwhm=999`.

 Closes #48 
